### PR TITLE
Add meters to distance related answers making is more useful for international visitors

### DIFF
--- a/src/views/Questions/Question09.js
+++ b/src/views/Questions/Question09.js
@@ -10,31 +10,31 @@ class Question09 extends QuizQuestion{
             question:'When walking past someone on the street, I keep...',
             answers:[
                 {
-                    copy:'at least 6 ft away from them',
+                    copy:'at least 6 ft / 2 m away from them',
                     color:'#9dd5e2',
                     points:'5',
                     correct:true
                 },
                 {
-                    copy:'at least 4 ft away from them',
+                    copy:'at least 4 ft / 1.5 m away from them',
                     color:'#7bc3d5',
                     points:'3',
                     correct:false
                 },
                 {
-                    copy:'at least 2 ft away from them',
+                    copy:'at least 2 ft / 1 m away from them',
                     color:'#60b2c8',
                     points:'3',
                     correct:false
                 },
                 {
-                    copy:'at least 0 ft away from them',
+                    copy:'at least 0 ft / 0 m away from them',
                     color:'#60b2c8',
                     points:'0',
                     correct:false
                 }
             ],
-            message:'CDC advises that the virus can spread within a distance of 6ft, so it is recommended to keep at least 6 feet between yourself and others.',
+            message:'CDC advises that the virus can spread within a distance of 6ft/2m, so it is recommended to keep at least 6 feet / 2 meters between yourself and others.',
             sourceurl:'https://www.cdc.gov/coronavirus/2019-ncov/prepare/transmission.html',
             source:'CDC.gov',
             questionpanelnumber:9,


### PR DESCRIPTION
Done a liberal translation for the distances tho. It translates as the following:
6 feet = 1.8 meters
4 feet = 1.2 meters
2 feet = 0.6 meters

Mainly done this to keep it easier eyes and less space used on the UI.